### PR TITLE
Renaming AB tests to experiments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": ">=7.1",
         "humanmade/hm-gtm": "^2.0.0",
         "altis/aws-analytics": "^1.0.0",
-        "altis/experiments": "^1.0.0"
+        "altis/experiments": "^1.1.0"
     },
     "license": "GPL-2.0",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": ">=7.1",
         "humanmade/hm-gtm": "^2.0.0",
         "altis/aws-analytics": "^1.0.0",
-        "altis/ab-tests": "^1.0.0"
+        "altis/experiments": "^1.0.0"
     },
     "license": "GPL-2.0",
     "authors": [

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,11 +8,11 @@ Altis provides its own analytics layer as part of the infrastructure by default.
 
 [Read more about native Altis Analytics](./native.md)
 
-## AB Testing
+## Web Experiments
 
-Built on top of the native analytics feature AB testing provides editorial teams with the ability to test the effectiveness of their content, and developers an extensible API for creating fully customised tests.
+Built on top of the native analytics feature the web experimentation framework provides features such as A/B testing for editorial teams to test the effectiveness of their content and developers with an extensible API for creating custom tests.
 
-[Read more about AB Testing in Altis](./ab-testing.md)
+[Read more about web experiments in Altis](./experiments.md)
 
 ## Google Tag Manager
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -9,7 +9,7 @@ The feature is enabled by default and provides a developer API for creating cust
 - Tests run until the end date or when a statistically significant improvement has been found
 - When a winner is found the winning variant will be shown to everyone
 
-The following built in tests are provided:
+The following built in experiments are provided:
 
 ### Post Title A/B Tests
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -123,7 +123,7 @@ The callback receives the following parameters:
 The `closest` parameter allows you to ensure the element passed to your callback is of a certain type, achieved by stepping up through the DOM tree, for example to return only anchor tags you would pass `[ 'a' ]`.
 
 ```js
-Altis.Analytics.ABTest.registerGoal( 'scrollIntoView', function ( element, record ) {
+Altis.Analytics.Experiments.registerGoal( 'scrollIntoView', function ( element, record ) {
 	var listener = function () {
 		// Check element has come into view or not.
 		if ( element.getBoundingClientRect().top > window.innerHeight ) {

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1,8 +1,8 @@
-# AB Testing
+# Experiments
 
-Backed by [native Altis Analytics](./native.md) AB testing is a powerful tool for optimising content and measuring the effectiveness of discrete changes to the site.
+Backed by [native Altis Analytics](./native.md) Experiments are a powerful tool for optimising content and measuring the effectiveness of changes to the site.
 
-The AB testing feature is enabled by default and provides a developer API for creating custom tests along with built in features.
+The feature is enabled by default and provides a developer API for creating custom experiments as well as some built in features.
 
 ## Features
 
@@ -11,7 +11,7 @@ The AB testing feature is enabled by default and provides a developer API for cr
 
 The following built in tests are provided:
 
-### Post titles
+### Post Title A/B Tests
 
 With this feature enabled it's simple to create AB Tests for your post titles directly from the post edit screen.
 
@@ -24,7 +24,7 @@ It is enabled by default but can be disabled via the configuration file:
 			"modules": {
 				"analytics": {
 					"native": {
-						"ab-tests": {
+						"experiments": {
 							"titles": false
 						}
 					}
@@ -58,7 +58,7 @@ Sets up the test.
   - `query_filter <string | callable>`: Elasticsearch bool query to filter total events being queried.
   - `variant_callback <callable>`: An optional callback used to render variants based. Recieves the variant value, test ID and post ID as arguments. By default passes the variant value through directly.
 
-**`output_test_html_for_post( string $test_id, int $post_id, string $default_content, array $args = [] )`**
+**`output_ab_test_html_for_post( string $test_id, int $post_id, string $default_content, array $args = [] )`**
 
 Returns the AB Test markup for client side processing.
 
@@ -68,7 +68,7 @@ Returns the AB Test markup for client side processing.
 - `$args`: An optional array of data to pass through to `variant_callback`.
 
 ```php
-namespace Altis\AB_Tests;
+namespace Altis\Experiments;
 
 // Register the test.
 register_post_ab_test( 'featured_images', [
@@ -86,7 +86,7 @@ register_post_ab_test( 'featured_images', [
 
 // Apply the test by filtering some standard output.
 add_filter( 'post_thumbnail_html', function ( $html, $post_id, $post_thumbnail_id, $size, $attr ) {
-	return output_test_html_for_post( 'featured_images', $post_id, $html, [
+	return output_ab_test_html_for_post( 'featured_images', $post_id, $html, [
 		'size' => $size,
 		'attr' => $attr,
 	] );
@@ -109,7 +109,7 @@ For example setting the goal to `click:.my-target` will track a conversion when 
 
 You can define your own goal handlers in JavaScript:
 
-**`Altis.Analytics.ABTest.registerGoal( name <string>, callback <function>, closest <array> )`**
+**`Altis.Analytics.Experiments.registerGoal( name <string>, callback <function>, closest <array> )`**
 
 This function adds a goal handler where `name` corresponds to the value of `$options['goal']` when registering an AB Test.
 
@@ -150,17 +150,17 @@ How you manage the variant data is up to you, for example you could use Fieldman
 
 Note you should use the following functions to get and update the variants:
 
-**`get_test_variants_for_post( string $test_id, int $post_id ) : array`**
+**`get_ab_test_variants_for_post( string $test_id, int $post_id ) : array`**
 
-**`update_test_variants_for_post( string $test_id, int $post_id, array $variants )`**
+**`update_ab_test_variants_for_post( string $test_id, int $post_id, array $variants )`**
 
-## Testing AB Tests
+## Testing Experiments
 
-In order to see your AB Tests working locally you can direct traffic to your development environment using the [Trafficator](https://github.com/humanmade/trafficator) tool.
+In order to see your experiments working locally you need to generate enough traffic to get statistically significant results. You can direct traffic to your development environment using the [Trafficator](https://github.com/humanmade/trafficator) tool.
 
 Install it by running `npm install -g trafficator`.
 
-Create a file called `.trafficator.js` that will perform the necessary actions to trigger conversions. The following example tests the built in `titles` tests by doing the following:
+Create a file called `.trafficator.js` that will perform the necessary actions to trigger conversions. The following example tests the built in `titles` experiment by doing the following:
 
 - generate visits to the home page of your local site
 - check the stored tests value, for post ID 1 this is `titles_1`

--- a/inc/native/namespace.php
+++ b/inc/native/namespace.php
@@ -21,14 +21,14 @@ function bootstrap() {
 	} );
 
 	// Load AB Tests.
-	if ( $config['ab-tests'] ) {
-		load_ab_tests();
+	if ( $config['experiments'] ) {
+		load_experiments();
 
-		// Enable/Disable AB Test Features.
-		if ( is_array( $config['ab-tests'] ) ) {
-			foreach ( $config['ab-tests'] as $feature => $enabled ) {
+		// Enable/Disable Experiments Features.
+		if ( is_array( $config['experiments'] ) ) {
+			foreach ( $config['experiments'] as $feature => $enabled ) {
 				add_filter(
-					"altis.ab_tests.features.{$feature}",
+					"altis.experiments.features.{$feature}",
 					$enabled ? '__return_true' : '__return_false'
 				);
 			}
@@ -39,6 +39,6 @@ function bootstrap() {
 /**
  * Load AB Tests plugin.
  */
-function load_ab_tests() {
-	require_once ROOT_DIR . '/vendor/altis/ab-tests/plugin.php';
+function load_experiments() {
+	require_once ROOT_DIR . '/vendor/altis/experiments/plugin.php';
 }

--- a/inc/native/namespace.php
+++ b/inc/native/namespace.php
@@ -20,7 +20,7 @@ function bootstrap() {
 		return get_elasticsearch_url();
 	} );
 
-	// Load AB Tests.
+	// Load Experiments.
 	if ( $config['experiments'] ) {
 		load_experiments();
 
@@ -37,7 +37,7 @@ function bootstrap() {
 }
 
 /**
- * Load AB Tests plugin.
+ * Load Experiments plugin.
  */
 function load_experiments() {
 	require_once ROOT_DIR . '/vendor/altis/experiments/plugin.php';

--- a/load.php
+++ b/load.php
@@ -20,7 +20,7 @@ add_action( 'altis.modules.init', function () {
 	$default_settings = [
 		'enabled' => true,
 		'native' => [
-			'ab-tests' => [
+			'experiments' => [
 				'titles' => true,
 			],
 		],


### PR DESCRIPTION
Updates AB Tests feature to the more general "Experiments" name.