### PR TITLE
Fix typo in ES Query example.

### DIFF
--- a/docs/native.md
+++ b/docs/native.md
@@ -244,7 +244,7 @@ $result = Altis\Analytics\Utils\query( [
     // Create a stats aggregation for all the time on page values found above.
     'stats' => [
       'stats_bucket' => [
-        'buckets_path' => 'sessions>time_in_page'
+        'buckets_path' => 'sessions>time_on_page'
       ]
     ]
   ],


### PR DESCRIPTION
There was another typo in the example that broke the query. 