### PR TITLE
Update hm-gtm to 2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "package",
     "require": {
         "php": ">=7.1",
-        "humanmade/hm-gtm": "^2.0.0",
+        "humanmade/hm-gtm": "^2.0.2",
         "altis/aws-analytics": "^1.0.0",
         "altis/experiments": "2.0.4"
     },


### PR DESCRIPTION
Fixes a bug on activation where the `get_plugin_data()` function was not included. Missed because I was logged in 🤦‍♂ 