### PR TITLE
Update AWS Analytics to 2.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=7.1",
         "humanmade/hm-gtm": "~2.0.2",
-        "altis/aws-analytics": "~2.2.5",
+        "altis/aws-analytics": "~2.3.0",
         "altis/experiments": "~2.2.2"
     },
     "license": "GPL-2.0",


### PR DESCRIPTION
This brings in the permissions fix so audience permissions match page editing permissions by default.