### PR TITLE
Do not clone AB test meta data

### DIFF
--- a/inc/native/namespace.php
+++ b/inc/native/namespace.php
@@ -50,6 +50,9 @@ function bootstrap() {
 
 	// Add endpoint data from cloudfront headers.
 	add_filter( 'altis.analytics.data.endpoint', __NAMESPACE__ . '\\add_endpoint_data' );
+
+	// Post cloner integration.
+	add_filter( 'post_cloner_meta_patterns_to_remove', __NAMESPACE__ . '\\post_cloner_meta_patterns_to_remove' );
 }
 
 /**
@@ -170,4 +173,16 @@ function add_endpoint_data( array $data ) : array {
 	}
 
 	return $data;
+}
+
+/**
+ * Meta patterns to avoid cloning.
+ *
+ * @param array $patterns Array of regex patterns to ignore.
+ * @return array
+ */
+function post_cloner_meta_patterns_to_remove( array $patterns ) : array {
+	// Ignore AB test data.
+	$patterns[] = '/^_altis_ab_test_.*/';
+	return $patterns;
 }


### PR DESCRIPTION
An AB test might be in progress or some other state of activity, we should avoid copying them across. Additionally cloning this data appears to cause a fatal error as some meta data fails to be unserialised during a REST request. Will investigate further on the experiments repo.