### PR TITLE
Documentation fixes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,12 +10,6 @@ Altis provides its own analytics layer as part of the infrastructure by default.
 
 [Read more about native Altis Analytics](./native/README.md)
 
-## Web Experiments
-
-Built on top of the native analytics feature the web experimentation framework provides editorial teams with features such as A/B testing to test the effectiveness of their content and developers with an extensible API for creating custom tests.
-
-[Read more about web experiments in Altis](./experiments.md)
-
 ## Google Tag Manager
 
 There are many 3rd party providers of analytics so this module provides a simple interface to add [Google Tag Manager](https://tagmanager.google.com/) containers, the recommended way to add and manage 3rd party JavaScript on your site.
@@ -23,3 +17,9 @@ There are many 3rd party providers of analytics so this module provides a simple
 Google Tag Manager provides comprehensive integration with [Google Analytics](google-tag-manager/google-analytics.md), [Google Optimize](google-tag-manager/optimize.md) and other tools in the 360 suite. Additionally, there is built-in support for services including [ChartBeat](https://chartbeat.com/), [comScore](https://www.comscore.com/), [Parse.ly](https://www.parse.ly/), [Hotjar](https://www.hotjar.com/) and [many more](https://support.google.com/tagmanager/answer/6106924).
 
 [Conversion tracking](google-tag-manager/conversion-tracking.md) can also be handled through GTM and the data collected used to set up [remarketing](google-tag-manager/remarketing.md).
+
+## Web Experiments
+
+Built on top of the native analytics feature the web experimentation framework provides editorial teams with features such as A/B testing to test the effectiveness of their content and developers with an extensible API for creating custom tests.
+
+[Read more about web experiments in Altis](./experiments.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Analytics is the gathering, understanding and application of data to measure, im
 
 ## Native Analytics
 
-Altis provides its own analytics layer as part of the infrastructure by default. This provides numerous benefits, not only from the perspective of GDPR, privacy, and owning your data but it enables powerful features including real time stats, AB testing, and personalization.
+Altis provides its own analytics layer as part of the infrastructure by default. This provides numerous benefits, not only from the perspective of GDPR, privacy, and owning your data but it enables powerful features including real time stats, A/B testing, and personalization.
 
 [Read more about native Altis Analytics](./native/README.md)
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -35,7 +35,7 @@ It is enabled by default but can be disabled via the configuration file:
 }
 ```
 
-Within the post edit screen click on the lightbulb icon to access the Experiments panel. Here you can set the alternative titles, the amount of traffic to show the tests to as well as start and end dates.
+Within the post edit screen click on the A/B icon to access the Experiments panel. Here you can set the alternative titles, the amount of traffic to show the tests to as well as start and end dates.
 
 Once you are ready to run the test click on the toggle to unpause it. Results are updated every hour until a statistically significant winner is found.
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -65,11 +65,11 @@ Sets up the test.
   - `goal <string>`: The conversion goal event name, eg "click" or "click:.selector a".
   - `goal_filter <string | callable>`: Elasticsearch bool query to filter goal results. If a callable is passed it receives the test ID and post ID as arguments.
   - `query_filter <string | callable>`: Elasticsearch bool query to filter total events being queried. If a callable is passed it receives the test ID and post ID as arguments.
-  - `variant_callback <callable>`: An optional callback used to render variants based. Arguments:
+  - `variant_callback <callable>`: An optional callback used to render variants based.
     - `$value <mixed>`: The variant value.
     - `$post_id <int>`: The post ID.
     - `$args <array>`: Optional args passed to `output_ab_test_html_for_post()`.
-  - `winner_callback <callable>`: An optional callback used to perform updates to the post when a winner is found. Defaults to no-op. Arguments:
+  - `winner_callback <callable>`: An optional callback used to perform updates to the post when a winner is found. Defaults to no-op.
     - `$post_id <int>`: The post ID
     - `$value <mixed>`: The winning variant value.
   - `post_types <array>`: An array of supported post types for the test.

--- a/docs/google-tag-manager/data-layer.md
+++ b/docs/google-tag-manager/data-layer.md
@@ -1,6 +1,6 @@
 # Data Layer
 
-Google Tag Manager provides a lot of variables out of the box that can be used in triggers and also in tags themselves however sometimes you need some additional data from the application itself.
+Google Tag Manager (GTM) provides a lot of variables out of the box that can be used in triggers and also in tags themselves however sometimes you need some additional data from the application itself.
 
 You can supply this extra data via GTM's data layer feature.
 

--- a/docs/google-tag-manager/remarketing.md
+++ b/docs/google-tag-manager/remarketing.md
@@ -1,6 +1,6 @@
 # Remarketing
 
-Remarketing can be configured through a custom script tag, the Google Ads remarketing tag or through Google Analytics. The latter approach is recommended if you are using GA.
+Remarketing can be configured through a custom script tag, the Google Ads remarketing tag or through Google Analytics (GA). The latter approach is recommended if you are using GA.
 
 Once you have Google Analytics and [conversion tracking](conversion-tracking.md) configured in Tag Manager you can use that information within Google Analytics to enable remarketing and create Audience Definitions.
 
@@ -11,7 +11,7 @@ You should link your ad provider accounts to the current GA property from the GA
 In the GA admin section:
 
 1. Select "Audience Definitions" and then the "Audiences" sub option
-2. Follow the steps there to enable remarketing. A default "All users" audience will be created for you. 
+2. Follow the steps there to enable remarketing. A default "All users" audience will be created for you.
 3. Click the blue "Enable" button
 
 The Audiences page will now show you a list of your audiences, and you can create new audiences here based many facets including:


### PR DESCRIPTION
* adds a slash for "A/B" testing
* moves web experiments docs down so they match the order in the sidebar
* changes "lightbulb icon" to "A/B icon"
* adds "GTM" acronym on Google Tag Manager -> Data Layer page
* adds "GA" acronym on Google Tag Manager -> Remarketing page