### PR TITLE
Update AWS Analytics to 2.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=7.1",
         "humanmade/hm-gtm": "~2.0.2",
-        "altis/aws-analytics": "~2.4.0",
+        "altis/aws-analytics": "~2.5.0",
         "altis/experiments": "~2.4.0"
     },
     "license": "GPL-2.0",

--- a/docs/google-tag-manager/README.md
+++ b/docs/google-tag-manager/README.md
@@ -54,3 +54,7 @@ add_filter( 'hm_gtm_network_id', function ( string $id ) : string {
 ```
 
 **Note** it is not recommended practice to do this, instead you should provide any conditional context you need via [the `dataLayer` variable](data-layer.md) and load all tags from a single container if possible.
+
+## Cookie Consent Integration
+
+Altis provides support out of the box for checking cookie consent in Google Tag Manager via the Altis Privacy module. You can [learn how to configure Google Tag Manager for cookie consent here](docs://privacy/consent/google-tag-manager.md).

--- a/docs/native/data-export.md
+++ b/docs/native/data-export.md
@@ -1,0 +1,28 @@
+# Data Export
+
+In order to export your analytics data for use in other Business Intelligence tools you can do so using the analytics events API endpoint.
+
+This approach requires requests to be authenticated. The simplest and most secure way to do this is using an application password. You can create one from your [profile page in the admin](admin://profile.php).
+
+## API Endpoint
+
+**`GET /wp-json/analytics/v1/events/<YYYY-MM-DD>`**
+
+Arguments:
+
+- `format`: one of "csv" or "json", defaults to "json".
+- `chunk_size`: the number of records to output at a time in the streamed response. A lower number will yield results more quickly but may encounter errors if you have a lot of records. A higher number will yield results more slowly and may result in a timeout or memory issues. Defaults to 3000, max value is 10000.
+
+## Using cURL
+
+To download data in CSV format for a given day using cURL and an application password use the command below with the following replacements:
+
+- `<YYYY-MM-DD>` should be replaced with your target date
+- `<username>` should be the user name you created the application password for
+- `<password>` should be your application password
+
+```
+curl -o <YYYY-MM-DD>.csv \
+  -u "<username>:<password>" \
+  https://example.com/wp-json/analytics/v1/events/<YYYY-MM-DD>?format=csv
+```

--- a/docs/native/data-structure.md
+++ b/docs/native/data-structure.md
@@ -23,7 +23,7 @@ _The most important thing to note is that the endpoint data is merged into event
 
 ### Privacy
 
-In order to protect your users privacy it is vital to follow these guidelines to get the most out of the built in integration with the [Altis Privacy module Consent feature](docs://privacy/consent/README.md).
+In order to protect your users privacy it is vital to follow these guidelines to get the most out of the built-in integration with the [Altis Privacy module Consent feature](docs://privacy/consent/README.md).
 
 - Event attributes and metrics should only contain data related directly to the event or URL
 - Endpoint attributes and metrics should only ever contain broad demographic data used for creating audiences

--- a/docs/native/data-structure.md
+++ b/docs/native/data-structure.md
@@ -9,17 +9,29 @@ New indexes are automatically created every day.
 The are two key concepts to understand the analytics data itself:
 
 - **Endpoints**
+  - Persistent data
   - Correspond to a unique device & browser combination
-  - Can be associated with a known user account via the `Endpoint.User.UserId` property. This is done automatically for logged in users.
-  - Persist across sessions
+  - Can be associated with a known user account via the `endpoint.User.UserId` property. This is done automatically for logged in users.
   - Updated via the `Altis.Analytics.updateEndpoint()` function
 - **Events**
+  - Point in time data specific to the current URL or user action
   - Has to be of a specific "type" eg. "pageView"
   - Can have custom attributes and metrics
-  - Data for the current endpoint is merged in
   - Created via the `Altis.Analytics.record()` function
 
 _The most important thing to note is that the endpoint data is merged into events, not provided when recording the events._
+
+### Privacy
+
+In order to protect your users privacy it is vital to follow these guidelines to get the most out of the built in integration with the [Altis Privacy module Consent feature](docs://privacy/consent/README.md).
+
+- Event attributes and metrics should only contain data related directly to the event or URL
+- Endpoint attributes and metrics should only ever contain broad demographic data used for creating audiences
+- Any personally identifiable information or other private user data that needs to be tracked should be stored as user attributes under the `endpoint.User.UserAttributes` property
+
+The `endpoint.User.UserId` value is automatically populated for logged in users, however, if users have not consented to the `statistics` category of cookies the user ID and user attributes are not recorded. Only `statistics-anonymous` consent is opted into by default.
+
+You can [learn more about privacy with Altis Native Analytics here](./privacy.md ).
 
 ## Anatomy of an Event Record
 

--- a/docs/native/privacy.md
+++ b/docs/native/privacy.md
@@ -6,7 +6,7 @@ Altis Analytics by default does not record visitor IP addresses to help protect 
 
 Altis Analytics integrates natively with the [Altis Privacy module Consent feature](docs://privacy/consent/README.md) and requires the `statistics-anonymous` category to be consented to at a minimum.
 
-While the `statistics-anonymous` consent category is opted into by default that can be changed via a filter if you have strict requirements regarding tracking.
+While the `statistics-anonymous` consent category is opted into by default, that option can be changed via a filter if you have strict requirements regarding tracking.
 
 ```php
 // Only allow functional cookies by default.

--- a/docs/native/privacy.md
+++ b/docs/native/privacy.md
@@ -2,9 +2,29 @@
 
 Altis Analytics by default does not record visitor IP addresses to help protect privacy.
 
+## Cookie Consent
+
+Altis Analytics integrates natively with the [Altis Privacy module Consent feature](docs://privacy/consent/README.md) and requires the `statistics-anonymous` category to be consented to at a minimum.
+
+While the `statistics-anonymous` consent category is opted into by default that can be changed via a filter if you have strict requirements regarding tracking.
+
+```php
+// Only allow functional cookies by default.
+add_filter( 'altis.consent.allowlisted_categories', function () {
+	return [ 'functional' ];
+} );
+```
+
+Without the `statistics` category of consent the `endpoint.User` data will be stripped from the data sent to Altis Analytics. To help protect your user's privacy any personally identifiable information should only ever be stored under the `endpoint.User.UserAttributes` property. You can read more about this in the section on [Data Structure](./data-structure.md).
+
 ## Data Retention
 
-Analytics data is retained by default for 14 days. This value can be configured up to a maximum of 60 days.
+Analytics data is stored in 2 locations:
+
+- S3 backup
+- Elasticsearch
+
+S3 backup data older than 90 days is automatically removed. Elasticsearch data is retained by default for 14 days. This value can be configured up to a maximum of 60 days.
 
 Insights and metrics can be calculated and updated using scheduled tasks to keep track of data such as the number of page views over time without needing to query the entire history of analytics data. This will keep queries faster and help to protect you visitor's privacy, and can also eliminate the need for requiring visitor's to opt in in the same way Google Analytics does.
 

--- a/docs/native/privacy.md
+++ b/docs/native/privacy.md
@@ -15,7 +15,7 @@ add_filter( 'altis.consent.allowlisted_categories', function () {
 } );
 ```
 
-Without the `statistics` category of consent the `endpoint.User` data will be stripped from the data sent to Altis Analytics. To help protect your user's privacy any personally identifiable information should only ever be stored under the `endpoint.User.UserAttributes` property. You can read more about this in the section on [Data Structure](./data-structure.md).
+Without the `statistics` category of consent, the `endpoint.User` data will be stripped from the data sent to Altis Analytics. To help protect your user's privacy, any personally identifiable information should only ever be stored under the `endpoint.User.UserAttributes` property. You can read more about this in the section on [Data Structure](./data-structure.md).
 
 ## Data Retention
 


### PR DESCRIPTION
This also adds documentation for the new features including the privacy module integration and data export.

Fixes #100