### PR TITLE
Docs specify personalized content

### DIFF
--- a/docs/native/experience-blocks.md
+++ b/docs/native/experience-blocks.md
@@ -6,7 +6,7 @@ The blocks themselves are backed by analytics data and [audiences](./audiences.m
 
 ## Personalization
 
-Because it's crucial that web pages can be fully cached for performance we provide [web components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) that are simple to use and load immediately as the document is loaded.
+Altis empowers editorial teams to create personalized content with the Personalized Content Experience Block. Because it's crucial that web pages can be fully cached for performance, our Personalized Content blocks use [web components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) that are simple to use and load immediately as the document is loaded.
 
 The web component `<personalization-block>` can be used anywhere on your pages to show content conditionally according to the audience segments the current website visitor matches.
 

--- a/docs/native/experience-blocks.md
+++ b/docs/native/experience-blocks.md
@@ -1,6 +1,6 @@
 # Experience Blocks
 
-Altis [Experience Blocks](https://www.altis-dxp.com/experience-blocks/) are built-in blocks for the editor that provide advanced capabilities. We are continually extending the range and uses of these blocks.
+Altis [Experience Blocks](https://www.altis-dxp.com/experience-blocks/) (XBs) are built-in blocks for the editor that provide advanced capabilities. We are continually extending the range and uses of these blocks.
 
 The blocks themselves are backed by analytics data and [audiences](./audiences.md) making it possible to record interactions and impressions with specific pieces of content on your pages. This document outlines the underlying mechanism so that you can implement these blocks outside of the scope of the block editor.
 


### PR DESCRIPTION
Our developer docs have a section titled Experience Blocks, but it never actually mentions Experience Blocks or Personalized Content Blocks. Rather, it focuses pretty exclusively on describing the `<personalization-block>` web component that Personalized Content Blocks add.

This PR adds a bit of introduction to Personalized Content blocks and the idea that they are Experience Blocks with room left for additional types of Experience Blocks to be added to the doc as they are integrated into Altis.