### PR TITLE
remove the post cloner integration

### DIFF
--- a/inc/native/namespace.php
+++ b/inc/native/namespace.php
@@ -63,10 +63,6 @@ function bootstrap() {
 
 	// Add endpoint data from cloudfront headers.
 	add_filter( 'altis.analytics.data.endpoint', __NAMESPACE__ . '\\add_endpoint_data' );
-
-	// Post cloner integration.
-	add_filter( 'post_cloner_meta_patterns_to_remove', __NAMESPACE__ . '\\post_cloner_meta_patterns_to_remove' );
-	add_filter( 'post_cloner_duplicate_post', __NAMESPACE__ . '\\post_cloner_update_xb_client_ids' );
 }
 
 /**
@@ -180,34 +176,4 @@ function add_endpoint_data( array $data ) : array {
 	}
 
 	return $data;
-}
-
-/**
- * Meta patterns to avoid cloning.
- *
- * @param array $patterns Array of regex patterns to ignore.
- * @return array
- */
-function post_cloner_meta_patterns_to_remove( array $patterns ) : array {
-	// Ignore AB test data.
-	$patterns[] = '/^_altis_ab_test_.*/';
-	return $patterns;
-}
-
-/**
- * Update XB client IDs when cloning a post.
- *
- * @param array $post The duplicated post data.
- * @return array
- */
-function post_cloner_update_xb_client_ids( array $post ): array {
-	$post['post_content'] = preg_replace_callback(
-		'#<!-- wp:altis/(personalization|experiment)\s+{.*?"clientId":"([a-z0-9-]+)"#',
-		function ( array $matches ) : string {
-			return str_replace( $matches[2], wp_generate_uuid4(), $matches[0] );
-		},
-		$post['post_content']
-	);
-
-	return $post;
 }


### PR DESCRIPTION
Removes the post cloner integration. 

This functionality is replaced by Duplicate Post and the filters added in humanmade/altis-workflow#70.