### PR TITLE
Fix incorrect namespace usage

### DIFF
--- a/inc/native/namespace.php
+++ b/inc/native/namespace.php
@@ -6,12 +6,9 @@
 namespace Altis\Analytics\Native;
 
 use Altis;
+use Altis\Analytics\Experiments;
 use Altis\Module;
-
-use function Altis\Experiments\get_ab_test_variants_for_post;
-use function Altis\Experiments\get_post_ab_test;
-use function Altis\get_config;
-use function HM\Workflows\get_post_assignees;
+use HM\Workflows;
 use HM\Workflows\Event;
 use HM\Workflows\Workflow;
 
@@ -20,7 +17,7 @@ use HM\Workflows\Workflow;
  */
 function bootstrap() {
 
-	$config = get_config()['modules']['analytics']['native'];
+	$config = Altis\get_config()['modules']['analytics']['native'];
 
 	// Use defaults if `$config` is just set to `true`.
 	if ( ! is_array( $config ) ) {
@@ -69,7 +66,7 @@ function bootstrap() {
 		}
 
 		// Experiments notifications.
-		if ( get_config()['modules']['workflow']['enabled'] ) {
+		if ( Altis\get_config()['modules']['workflow']['enabled'] ) {
 			add_action( 'plugins_loaded', __NAMESPACE__ . '\\setup_notifications', 12 );
 		}
 	}
@@ -85,8 +82,8 @@ function bootstrap() {
  * @return int
  */
 function set_data_retention_days( int $days ) : int {
-	if ( get_config()['modules']['analytics']['native']['data-retention-days'] ?? false ) {
-		return get_config()['modules']['analytics']['native']['data-retention-days'];
+	if ( Altis\get_config()['modules']['analytics']['native']['data-retention-days'] ?? false ) {
+		return Altis\get_config()['modules']['analytics']['native']['data-retention-days'];
 	}
 	return $days;
 }
@@ -123,17 +120,17 @@ function setup_notifications() {
 		}, __( 'Post author', 'altis-analytics' ) );
 
 		$event->add_recipient_handler( 'post_assignees', function ( string $test_id, int $post_id ) {
-			return get_post_assignees( $post_id );
+			return Workflows\get_post_assignees( $post_id );
 		}, __( 'Post assignees', 'altis-analytics' ) );
 
 		$event->add_message_tags( [
 			'test.title' => function ( string $test_id ) {
-				$test = get_post_ab_test( $test_id );
+				$test = Experiments\get_post_ab_test( $test_id );
 				return $test['label'];
 			},
 			'post.title' => function ( string $test_id, int $post_id ) {
 				$post = get_post( $post_id );
-				$variants = get_ab_test_variants_for_post( $test_id, $post_id );
+				$variants = Experiments\get_ab_test_variants_for_post( $test_id, $post_id );
 				return count( $variants ) ? $variants[0] : $post->post_title;
 			},
 		] );


### PR DESCRIPTION
This should have been done after the merge of Altis Experiments into the main analytics plugin in v7, my fault that it got missed.