### PR TITLE
Update the docs with the max index age default value

### DIFF
--- a/docs/native/api/server-side-api.md
+++ b/docs/native/api/server-side-api.md
@@ -109,7 +109,7 @@ Returning `true` from this filter will prevent any events or updated endpoint da
 
 **`altis.analytics.max_index_age <int>`**
 
-Filter the maximum number of days to keep real time stats available for. The default number of days is 14, after which data is removed. This is important for streamlining your user's privacy.
+Filter the maximum number of days to keep real time stats available for. The default number of days is 90, after which data is removed. This is important for streamlining your user's privacy.
 
 Insights and aggregated analytics data can be calculated, updated and stored in the database in cases where you wish to retain information for longer periods of time such as number of page views.
 


### PR DESCRIPTION
Related issue #265 

This PR sets the correct default value for the max index age ( `altis.analytics.max_index_age` )   in the docs as per the default configuration.