### PR TITLE
Update hm-gtm to use ^2.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "package",
     "require": {
         "php": ">=7.1",
-        "humanmade/hm-gtm": "~2.0.7",
+        "humanmade/hm-gtm": "^2.1.0",
         "altis/aws-analytics": "~4.6.6",
         "altis/analytics-integration-segment": "~0.2.0"
     },


### PR DESCRIPTION
Updates the `hm-gtm` dependency to use 2.1.0 or above. See discussion on https://github.com/humanmade/hm-gtm/pull/30

If this could be backported to the V8 branch I would deeply appreciate it 🥺 

## Changelog

### [2.1.0](https://github.com/humanmade/hm-gtm/releases/tag/2.1.0)

> Allow filtering of tag manager script tags with new hm_gtm_script_tag filter. https://github.com/humanmade/hm-gtm/pull/30

### [2.0.8](https://github.com/humanmade/hm-gtm/releases/tag/2.0.8)

> ## What's Changed
> * Check for existing window.dataLayer, append if found. by @Sephsekla in https://github.com/humanmade/hm-gtm/pull/29
> 
> ## New Contributors
> * @Sephsekla made their first contribution in https://github.com/humanmade/hm-gtm/pull/29
> 
> **Full Changelog**: https://github.com/humanmade/hm-gtm/compare/2.0.7...2.0.8

