### PR TITLE
[Backport v8-branch] Update hm-gtm to use ^2.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "package",
     "require": {
         "php": ">=7.1",
-        "humanmade/hm-gtm": "~2.0.7",
+        "humanmade/hm-gtm": "^2.1.0",
         "altis/aws-analytics": "~4.0.12"
     },
     "license": "GPL-2.0",


### PR DESCRIPTION
Backport https://github.com/humanmade/altis-analytics/pull/311.