### PR TITLE
Provide fallback for analytics.google-tag-manager config

### DIFF
--- a/inc/google_tag_manager/namespace.php
+++ b/inc/google_tag_manager/namespace.php
@@ -38,7 +38,7 @@ function bootstrap() {
  * @return array
  */
 function get_config() : array {
-	return get_platform_config()['modules']['analytics']['google-tag-manager'];
+	return get_platform_config()['modules']['analytics']['google-tag-manager'] ?? [];
 }
 
 /**


### PR DESCRIPTION
This was observed on Altis 8/9, but may be useful on more modern versions: there was no handling for cases where `analytics` was set, but the `google-tag-manager` key was not, meaning that a warning would be shown when running CLI commands: 

```
Notice: Undefined index: google-tag-manager in /usr/src/app/vendor/altis/privacy/inc/gtm/namespace.php on line 16
```

`[]` may not be the best fallback value, but I wanted to capture the thought while it was fresh. Unless I misunderstand how the configuration is accessed, I believe this could easily result in an undefined index warning as-is.