### PR TITLE
Manual update upstream aws-analytics to latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=7.1",
         "humanmade/hm-gtm": "^2.1.1",
-        "altis/aws-analytics": "~4.6.16",
+        "altis/aws-analytics": "~4.6.17",
         "altis/analytics-integration-segment": "~0.2.0"
     },
     "license": "GPL-2.0",


### PR DESCRIPTION
This pulls in PR https://github.com/humanmade/aws-analytics/pull/556 from upstream

Fixes issue with insights page not loading as results are semi-populated during API fetches.

Also resolves some issues with certain metrics not showing percentage symbols when they should.